### PR TITLE
test: 升级espresso版本到3.3.0-alpha05

### DIFF
--- a/projects/test/dynamic/host/test-dynamic-host/build.gradle
+++ b/projects/test/dynamic/host/test-dynamic-host/build.gradle
@@ -49,12 +49,12 @@ dependencies {
     implementation project(':constant')
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:core:1.1.1-alpha02'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1-alpha02'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0-alpha02'
-    androidTestImplementation 'androidx.test.espresso:espresso-remote:3.2.0-alpha02'
-    implementation 'androidx.test.espresso:espresso-idling-resource:3.2.0-alpha02'
-    androidTestImplementation "androidx.test:runner:1.1.2-alpha02"
+    androidTestImplementation 'androidx.test:core:1.3.0-alpha05'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2-alpha05'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0-alpha05'
+    androidTestImplementation 'androidx.test.espresso:espresso-remote:3.3.0-alpha05'
+    implementation 'androidx.test.espresso:espresso-idling-resource:3.3.0-alpha05'
+    androidTestImplementation "androidx.test:runner:1.3.0-alpha05"
 
     implementation project(':plugin-use-host-code-lib')
     implementation project(':test-manager')

--- a/projects/test/plugin/general-cases/general-cases-lib/build.gradle
+++ b/projects/test/plugin/general-cases/general-cases-lib/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'com.android.support:support-v4:27.1.1'
     implementation project(':custom-view')
 
-    compileOnly 'androidx.test.espresso:espresso-idling-resource:3.2.0-alpha02'
+    compileOnly 'androidx.test.espresso:espresso-idling-resource:3.3.0-alpha05'
 
     compileOnly project(':plugin-use-host-code-lib')
 }


### PR DESCRIPTION
可解决在Android R preview版本虚拟机上启动Activity失败的问题。

#300